### PR TITLE
Fix markdown not rendered inside details tags

### DIFF
--- a/2d/image.md
+++ b/2d/image.md
@@ -13,7 +13,7 @@ var image = new Sumo.Image()
 sumo.add(image)
 ```
 
-<details>
+<details markdown="1">
   <summary>See other examples</summary>
 You can give image source in constructor:
 
@@ -64,7 +64,7 @@ image.moveAlongCurve(1000, {
 
 ![preview](../images/curve-preview.gif)
 
-<details>
+<details markdown="1">
   <summary>See other examples</summary>
 
 Curve can also be given as an array:


### PR DESCRIPTION
Yeah there is a bug with github pages or with jekyll theme not sure but it won't render markdown inside details.
Native github markdown renderer renders it just fine without this attribute...